### PR TITLE
BLOGSPERL-246 removed cover.tt from index

### DIFF
--- a/views/index.tt
+++ b/views/index.tt
@@ -81,7 +81,6 @@
                          </div>
 
                          <!-- Post cover -->
-                         [% INCLUDE cover.tt %]
                          
                          <!-- Post content -->
                          <div class="post_preview truncate">


### PR DESCRIPTION
if you add one post with an img file from write a post tab that img displayed in index(home) page.
removed cover.tt  from there
