### PR TITLE
BLOGSPERL-256 Remove problematic session('app_url') from dashboard.

### DIFF
--- a/lib/PearlBee/Dashboard.pm
+++ b/lib/PearlBee/Dashboard.pm
@@ -51,8 +51,8 @@ any '/dashboard' => sub {
     }
   }
   else {
-    redirect session('app_url') . '/admin/posts'  if ( $user->is_admin );
-    redirect session('app_url') . '/author/posts';
+    redirect '/admin/posts'  if ( $user->is_admin );
+    redirect '/author/posts';
   }
 
 };


### PR DESCRIPTION
This caused the forgot_password mechanism to redirect wrongly + many other cases where the ip was duplicated.
