### PR TITLE
BLOGSPERL-285 - Implement search for tags

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -47,6 +47,7 @@ lib/PearlBee/Model/Schema/ResultSet/Comment.pm
 lib/PearlBee/Model/Schema/ResultSet/PostCategory.pm
 lib/PearlBee/Model/Schema/ResultSet/Post.pm
 lib/PearlBee/Model/Schema/ResultSet/PostTag.pm
+lib/PearlBee/Model/Schema/ResultSet/Tag.pm
 lib/PearlBee/Model/Schema/Result/Setting.pm
 lib/PearlBee/Model/Schema/Result/Tag.pm
 lib/PearlBee/Model/Schema/Result/Timezone.pm

--- a/lib/PearlBee/Model/Schema/ResultSet/Tag.pm
+++ b/lib/PearlBee/Model/Schema/ResultSet/Tag.pm
@@ -1,0 +1,21 @@
+package  PearlBee::Model::Schema::ResultSet::Tag;
+
+use strict;
+use warnings;
+
+use base 'DBIx::Class::ResultSet';
+
+=head2 Search for a tag case-insensitive
+
+=cut
+
+sub search_lc {
+  my ($self, $tag) = @_;
+  my $schema            = $self->result_source->schema;
+  
+  my $lc_tag = lc $tag; 
+  return $schema->resultset('Tag')->
+                  search( \[ "lower(name) like '\%$lc_tag\%'" ] );
+}
+
+1;


### PR DESCRIPTION
note: search is made after `name` because table tag is composed of id, name and slug.
